### PR TITLE
Fix signup form - migrate to Kit API v4

### DIFF
--- a/src/components/signup-form.tsx
+++ b/src/components/signup-form.tsx
@@ -22,15 +22,14 @@ export function SignupForm({ buttonText = "Get early access", className = "", da
     setStatus("loading");
 
     try {
-      // Subscribe via Kit (ConvertKit) API using the form endpoint
-      const response = await fetch("https://api.convertkit.com/v3/tags/15947810/subscribe", {
+      // Subscribe via Kit API v4 form endpoint
+      const response = await fetch("https://api.kit.com/v4/forms/9097515/subscribers", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          api_key: "kit_373287bfc9ba036f5460fdf3c5be6d8d",
-          email: email,
-          tags: [15947810],
-        }),
+        headers: {
+          "Content-Type": "application/json",
+          "X-Kit-Api-Key": "kit_373287bfc9ba036f5460fdf3c5be6d8d",
+        },
+        body: JSON.stringify({ email_address: email }),
       });
 
       if (response.ok) {


### PR DESCRIPTION
## Summary

Migrates the signup form from the broken ConvertKit v3 API to the Kit v4 API.

## Problem

The v3 endpoint (`https://api.convertkit.com/v3/tags/15947810/subscribe`) does not accept v4 API keys (`kit_*` prefix), causing all signup submissions to fail.

## Fix

Switched to the Kit v4 form subscribe endpoint:

- **Endpoint:** `POST https://api.kit.com/v4/forms/9097515/subscribers`
- **Auth:** `X-Kit-Api-Key` header instead of `api_key` in request body
- **Body:** `{ "email_address": "<email>" }` — simpler payload, form handles tagging automatically

## Changes

- `src/components/signup-form.tsx` — updated fetch URL, replaced body `api_key` + `email` + `tags` fields with header auth and `email_address` field per v4 spec

## Verified

Build passes with `npm run build` (Next.js 16 / Turbopack, 0 errors).