### PR TITLE
feat: SEO foundations — sitemap, robots.txt, schema markup, enhanced metadata

### DIFF
--- a/landing/public/robots.txt
+++ b/landing/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://levylite.com.au/sitemap.xml
+Host: https://levylite.com.au

--- a/landing/public/sitemap.xml
+++ b/landing/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://levylite.com.au/</loc>
+    <lastmod>2026-02-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/landing/src/app/layout.tsx
+++ b/landing/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Script from "next/script";
+
+const BASE_URL = "https://levylite.com.au";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -13,15 +16,45 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "LevyLite — Strata management software that doesn't cost the earth",
-  description: "Affordable strata management software for small Australian operators. $6/lot/month. No minimums. No sales calls. Built for sole practitioners and small agencies.",
-  keywords: ["strata management", "strata software", "levy management", "WA strata", "small strata operator", "affordable strata", "owner portal", "AGM management"],
+  metadataBase: new URL(BASE_URL),
+  title: {
+    default: "LevyLite — Affordable Strata Management Software for Small Operators",
+    template: "%s | LevyLite",
+  },
+  description:
+    "LevyLite is affordable strata management software built for small Australian operators. Levy tracking, AGM management, owner portal, and trust accounting — from $6/lot/month. No minimums. No sales calls.",
+  keywords: [
+    "strata management software",
+    "strata software australia",
+    "affordable strata software",
+    "small strata operator",
+    "levy management software",
+    "strata manager software",
+    "WA strata software",
+    "body corporate software",
+    "strata accounting software",
+    "AGM management software",
+    "owner portal strata",
+    "strata software perth",
+  ],
+  authors: [{ name: "LevyLite", url: BASE_URL }],
   openGraph: {
-    title: "LevyLite — Strata management software that doesn't cost the earth",
-    description: "Affordable strata management software for small Australian operators. $6/lot/month. No minimums.",
-    url: "https://levylite.com.au",
+    title: "LevyLite — Affordable Strata Management Software",
+    description:
+      "Strata management software built for small Australian operators. Levy tracking, AGM management, owner portal — from $6/lot/month.",
+    url: BASE_URL,
     siteName: "LevyLite",
+    locale: "en_AU",
     type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "LevyLite — Affordable Strata Management Software",
+    description:
+      "Built for small Australian strata operators. From $6/lot/month.",
+  },
+  alternates: {
+    canonical: BASE_URL,
   },
 };
 
@@ -35,6 +68,46 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Script
+          id="schema-org"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify([
+              {
+                "@context": "https://schema.org",
+                "@type": "Organization",
+                name: "LevyLite",
+                url: BASE_URL,
+                logo: `${BASE_URL}/kokoro-logo.png`,
+                description:
+                  "Affordable strata management software for small Australian operators.",
+                foundingDate: "2026",
+                address: {
+                  "@type": "PostalAddress",
+                  addressLocality: "Perth",
+                  addressRegion: "WA",
+                  addressCountry: "AU",
+                },
+              },
+              {
+                "@context": "https://schema.org",
+                "@type": "SoftwareApplication",
+                name: "LevyLite",
+                applicationCategory: "BusinessApplication",
+                operatingSystem: "Web",
+                url: BASE_URL,
+                description:
+                  "Strata management software for small Australian operators — levy tracking, AGM management, owner portal.",
+                offers: {
+                  "@type": "Offer",
+                  price: "0",
+                  priceCurrency: "AUD",
+                  description: "Free tier: up to 5 lots, 1 scheme",
+                },
+              },
+            ]),
+          }}
+        />
         {children}
       </body>
     </html>


### PR DESCRIPTION
Rebased version of PR #3 onto current master structure.

**Changes:**
- `landing/public/sitemap.xml` — all pages for Google crawling
- `landing/public/robots.txt` — references sitemap
- Enhanced `layout.tsx` metadata: 12 keywords, Twitter card, canonical URL, en_AU locale
- Organization + SoftwareApplication JSON-LD schema markup
- Build verified ✅

Closes #3 (supersedes original PR)