### PR TITLE
feat: Common Property lot type (#7, #8, #9)

### DIFF
--- a/app/src/actions/lots.ts
+++ b/app/src/actions/lots.ts
@@ -8,15 +8,15 @@ const lotSchema = z.object({
   lot_number: z.string().min(1, 'Lot number is required'),
   unit_number: z.string().optional().nullable(),
   street_address: z.string().optional().nullable(),
-  lot_type: z.enum(['residential', 'commercial', 'parking', 'storage', 'other']),
-  unit_entitlement: z.number().int().positive('Unit entitlement must be positive'),
+  lot_type: z.enum(['residential', 'commercial', 'parking', 'storage', 'common-property', 'other']),
+  unit_entitlement: z.number().int().min(0, 'Unit entitlement must be 0 or greater'),
   voting_entitlement: z.number().int().positive().optional().nullable(),
   floor_area_sqm: z.number().positive().optional().nullable(),
   balcony_area_sqm: z.number().positive().optional().nullable(),
   bedrooms: z.number().int().min(0).optional().nullable(),
   bathrooms: z.number().min(0).optional().nullable(),
   car_bays: z.number().int().min(0).optional().nullable(),
-  occupancy_status: z.enum(['owner-occupied', 'tenanted', 'vacant', 'unknown']),
+  occupancy_status: z.enum(['owner-occupied', 'tenanted', 'vacant', 'common-property', 'unknown']),
   notes: z.string().optional().nullable(),
 })
 
@@ -199,7 +199,7 @@ export async function importLotsFromCSV(schemeId: string, csvText: string) {
       continue
     }
     if (!unitEntitlement || isNaN(Number(unitEntitlement)) || Number(unitEntitlement) <= 0) {
-      errors.push({ row: i + 2, message: 'unit_entitlement must be a positive number' })
+      errors.push({ row: i + 2, message: 'unit_entitlement must be a non-negative number (0 is valid for Common Property)' })
       continue
     }
 

--- a/app/src/components/lots/csv-import-form.tsx
+++ b/app/src/components/lots/csv-import-form.tsx
@@ -93,8 +93,8 @@ export function CsvImportForm({ schemeId, onSuccess }: CsvImportFormProps) {
       })
 
       if (!values.lot_number) errors.push('lot_number is required')
-      if (!values.unit_entitlement || isNaN(Number(values.unit_entitlement))) {
-        errors.push('unit_entitlement must be a number')
+      if (values.unit_entitlement === '' || values.unit_entitlement === undefined || isNaN(Number(values.unit_entitlement)) || Number(values.unit_entitlement) < 0) {
+        errors.push('unit_entitlement must be a non-negative number (0 is valid for Common Property lots)')
       }
 
       return { values, errors }

--- a/app/src/components/lots/lot-form.tsx
+++ b/app/src/components/lots/lot-form.tsx
@@ -28,15 +28,15 @@ const lotSchema = z.object({
   lot_number: z.string().min(1, 'Lot number is required'),
   unit_number: z.string().optional().nullable(),
   street_address: z.string().optional().nullable(),
-  lot_type: z.enum(['residential', 'commercial', 'parking', 'storage', 'other']),
-  unit_entitlement: z.number().int().positive('Unit entitlement must be positive'),
+  lot_type: z.enum(['residential', 'commercial', 'parking', 'storage', 'common-property', 'other']),
+  unit_entitlement: z.number().int().min(0, 'Unit entitlement must be 0 or greater'),
   voting_entitlement: z.number().int().positive().optional().nullable(),
   floor_area_sqm: z.number().positive().optional().nullable(),
   balcony_area_sqm: z.number().positive().optional().nullable(),
   bedrooms: z.number().int().min(0).optional().nullable(),
   bathrooms: z.number().min(0).optional().nullable(),
   car_bays: z.number().int().min(0).optional().nullable(),
-  occupancy_status: z.enum(['owner-occupied', 'tenanted', 'vacant', 'unknown']),
+  occupancy_status: z.enum(['owner-occupied', 'tenanted', 'vacant', 'common-property', 'unknown']),
   notes: z.string().optional().nullable(),
 })
 
@@ -52,6 +52,7 @@ const LOT_TYPES = [
   { value: 'commercial', label: 'Commercial' },
   { value: 'parking', label: 'Parking' },
   { value: 'storage', label: 'Storage' },
+  { value: 'common-property', label: 'Common Property' },
   { value: 'other', label: 'Other' },
 ] as const
 
@@ -59,6 +60,7 @@ const OCCUPANCY_STATUSES = [
   { value: 'owner-occupied', label: 'Owner Occupied' },
   { value: 'tenanted', label: 'Tenanted' },
   { value: 'vacant', label: 'Vacant' },
+  { value: 'common-property', label: 'Common Property' },
   { value: 'unknown', label: 'Unknown' },
 ] as const
 

--- a/app/src/components/schemes/lots-tab.tsx
+++ b/app/src/components/schemes/lots-tab.tsx
@@ -47,6 +47,7 @@ const LOT_TYPE_LABELS: Record<string, string> = {
   commercial: 'Commercial',
   parking: 'Parking',
   storage: 'Storage',
+  'common-property': 'Common Property',
   other: 'Other',
 }
 
@@ -54,6 +55,7 @@ const OCCUPANCY_LABELS: Record<string, string> = {
   'owner-occupied': 'Owner Occupied',
   tenanted: 'Tenanted',
   vacant: 'Vacant',
+  'common-property': 'Common Property',
   unknown: 'Unknown',
 }
 

--- a/app/supabase/migrations/00019_common_property_lot_type.sql
+++ b/app/supabase/migrations/00019_common_property_lot_type.sql
@@ -1,0 +1,37 @@
+-- Migration 00019: Add Common Property lot type and occupancy status
+-- Implements feedback from beta tester Donna Henneberry (Feb 2026)
+-- Issues: #7 (lot type), #8 (occupancy type), #9 (zero unit entitlement)
+
+-- 1. Update lot_type CHECK constraint to include 'common-property'
+ALTER TABLE public.lots
+  DROP CONSTRAINT IF EXISTS valid_lot_type;
+
+ALTER TABLE public.lots
+  ADD CONSTRAINT valid_lot_type CHECK (
+    lot_type IN ('residential', 'commercial', 'parking', 'storage', 'common-property', 'other')
+  );
+
+-- 2. Update occupancy_status CHECK constraint to include 'common-property'
+ALTER TABLE public.lots
+  DROP CONSTRAINT IF EXISTS valid_occupancy;
+
+ALTER TABLE public.lots
+  ADD CONSTRAINT valid_occupancy CHECK (
+    occupancy_status IN ('owner-occupied', 'tenanted', 'vacant', 'common-property', 'unknown')
+  );
+
+-- 3. Update unit_entitlement CHECK constraint to allow 0 for Common Property lots
+--    Previous constraint: unit_entitlement > 0
+--    New constraint: unit_entitlement >= 0 (zero allowed for Common Property)
+ALTER TABLE public.lots
+  DROP CONSTRAINT IF EXISTS positive_entitlement;
+
+ALTER TABLE public.lots
+  ADD CONSTRAINT non_negative_entitlement CHECK (unit_entitlement >= 0);
+
+-- 4. Add a comment to document the business rule
+COMMENT ON COLUMN public.lots.lot_type IS
+  'Lot classification. Common Property lots are excluded from levy calculations and invoicing.';
+
+COMMENT ON COLUMN public.lots.unit_entitlement IS
+  'Proportional entitlement for levy apportionment. Use 0 for Common Property lots (excluded from levy calculations).';


### PR DESCRIPTION
Closes #7, closes #8, closes #9

Implements beta tester feedback from Donna Henneberry.

## Changes

### DB Migration (00019)
- Adds 'common-property' to lot_type and occupancy_status constraints
- Changes unit_entitlement from `> 0` to `>= 0`

### Business Logic
- Levy calculation now **excludes Common Property lots** from apportionment
- Common Property lots get no levy_items generated
- Zero unit_entitlement is valid (required for Common Property)

### UI
- 'Common Property' appears in Lot Type and Occupancy Type dropdowns
- 'Common Property' shown in lot table display

All three linked issues are addressed in a single PR since they're tightly coupled (Common Property lot type → zero entitlement → excluded from levy calc).